### PR TITLE
Fix Tier 1 review bugs: Makefile, missing txn datetime, account_id fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 all: test mypy black
 
-PHONY: test
+.PHONY: test
 test:
 	pytest
 
-PHONY: coverage
-coverage: bin/pytest
-	pytest --cov src/ofxstatement
+.PHONY: coverage
+coverage:
+	pytest --cov src/ofxstatement_otp
 
 .PHONY: black
 black:

--- a/setup.py
+++ b/setup.py
@@ -1,42 +1,43 @@
 #!/usr/bin/python3
-"""Setup
-"""
+"""Setup"""
+
 from setuptools import find_packages
 from distutils.core import setup
 
 version = "0.2.0"
 
-with open('README.rst') as f:
+with open("README.rst") as f:
     long_description = f.read()
 
-setup(name='ofxstatement-otp',
-      version=version,
-      author="Peter Gyongyosi",
-      author_email="gypeter@gmail.com",
-      url="https://github.com/gyp/ofxstatement-otp",
-      description=("ofxstatement plugin for the Hungarian bank OTP"),
-      long_description=long_description,
-      license="AGPLv3",
-      keywords=["ofx", "banking", "statement"],
-      classifiers=[
-          'Development Status :: 4 - Beta',
-          'Programming Language :: Python :: 3',
-          'Natural Language :: English',
-          'Topic :: Office/Business :: Financial :: Accounting',
-          'Topic :: Utilities',
-          'Environment :: Console',
-          'Operating System :: OS Independent',
-          'License :: OSI Approved :: GNU Affero General Public License v3'],
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      entry_points={
-          'ofxstatement':
-          [
-              'otp = ofxstatement_otp.otp:OtpPlugin',
-              'otp_legacy = ofxstatement_otp.otp_legacy:OtpLegacyPlugin'
-          ]
-          },
-      install_requires=['ofxstatement', 'openpyxl'],
-      include_package_data=True,
-      zip_safe=True
-      )
+setup(
+    name="ofxstatement-otp",
+    version=version,
+    author="Peter Gyongyosi",
+    author_email="gypeter@gmail.com",
+    url="https://github.com/gyp/ofxstatement-otp",
+    description=("ofxstatement plugin for the Hungarian bank OTP"),
+    long_description=long_description,
+    license="AGPLv3",
+    keywords=["ofx", "banking", "statement"],
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Programming Language :: Python :: 3",
+        "Natural Language :: English",
+        "Topic :: Office/Business :: Financial :: Accounting",
+        "Topic :: Utilities",
+        "Environment :: Console",
+        "Operating System :: OS Independent",
+        "License :: OSI Approved :: GNU Affero General Public License v3",
+    ],
+    packages=find_packages("src"),
+    package_dir={"": "src"},
+    entry_points={
+        "ofxstatement": [
+            "otp = ofxstatement_otp.otp:OtpPlugin",
+            "otp_legacy = ofxstatement_otp.otp_legacy:OtpLegacyPlugin",
+        ]
+    },
+    install_requires=["ofxstatement", "openpyxl"],
+    include_package_data=True,
+    zip_safe=True,
+)

--- a/src/ofxstatement_otp/otp.py
+++ b/src/ofxstatement_otp/otp.py
@@ -39,7 +39,7 @@ class Transaction:
     memo: str
     category: str
     bank_txn_id: str
-    transaction_date: datetime
+    transaction_date: Optional[datetime]
     booking_date: datetime
     amount: Decimal
     currency: str
@@ -167,7 +167,9 @@ class OtpXlsxParser(StatementParser):
             if not self._included(values[0]):
                 continue
 
-            values[7] = _to_datetime(values[7], DATETIME_FORMAT)
+            # The row is booked (booking date present, checked above); the
+            # transaction datetime may still be blank, so guard it.
+            values[7] = _to_datetime(values[7], DATETIME_FORMAT) if values[7] else None
             values[8] = _to_datetime(values[8], DATE_FORMAT)
             yield Transaction(*values)
 

--- a/src/ofxstatement_otp/otp.py
+++ b/src/ofxstatement_otp/otp.py
@@ -182,7 +182,13 @@ class OtpXlsxParser(StatementParser):
                 break
             if self._included(account_no):
                 return str(account_no)
-        return self.account_filter
+        if self.account_filter:
+            logger.warning(
+                "No transactions matched account filter %r; "
+                "leaving account_id unset",
+                self.account_filter,
+            )
+        return None
 
     def _get_currency(self) -> str:
         # Read the currency of the first matching transaction; default to HUF.

--- a/tests/test_otp.py
+++ b/tests/test_otp.py
@@ -101,6 +101,14 @@ def test_account_filter_is_substring_and_case_insensitive(sample_xlsx):
     assert all(line.payee in {"MEDIA MARKT", "OTP Bank"} for line in result.lines)
 
 
+def test_account_id_unset_when_filter_matches_nothing(sample_xlsx):
+    # A filter that matches no account must not pass itself off as the
+    # statement's account_id; it should be left unset.
+    statement, result = parse(sample_xlsx, {"account": "99999999"})
+    assert result.lines == []
+    assert statement.account_id is None
+
+
 def test_fitid_comes_from_bank_identifier(sample_xlsx):
     _, result = parse(sample_xlsx, {"account": CHECKING})
     first = result.lines[0]

--- a/tests/test_otp.py
+++ b/tests/test_otp.py
@@ -128,6 +128,35 @@ def test_trntype_mapping(sample_xlsx):
     assert by_payee["Valami Bolt"].trntype == "PAYMENT"
 
 
+def test_missing_transaction_datetime_does_not_crash(tmp_path):
+    # A booked row (booking date present) whose transaction datetime is blank
+    # must still be emitted, with date_user unset, rather than crashing.
+    wb = generate_sample.build_workbook()
+    ws = wb[generate_sample.TRANSACTIONS_SHEET_NAME]
+    ws.append(
+        [
+            CHECKING,
+            "",
+            "NO TXN TIME",
+            "VÁSÁRLÁS KÁRTYÁVAL",
+            "memo",
+            "Egyéb",
+            "2024012909999011010",
+            None,
+            "2024-01-29",
+            -100.00,
+            "HUF",
+        ]
+    )
+    path = tmp_path / "sample.xlsx"
+    wb.save(path)
+
+    _, result = parse(str(path), {"account": CHECKING})
+    line = next(line for line in result.lines if line.payee == "NO TXN TIME")
+    assert line.date == datetime(2024, 1, 29)
+    assert line.date_user is None
+
+
 def test_native_datetime_cell_is_parsed(sample_xlsx):
     # The MOL row uses a native datetime cell for the transaction date.
     _, result = parse(sample_xlsx, {"account": CHECKING})


### PR DESCRIPTION
Fixes the three correctness ("Tier 1") issues surfaced in the codebase review. Each is a separate commit.

## 1. Makefile: `.PHONY` typos, phantom prereq, wrong coverage path
`PHONY: test` / `PHONY: coverage` were missing the leading dot (declaring a real `PHONY` target instead of marking recipes phony); `coverage` depended on a non-existent `bin/pytest`; and `--cov src/ofxstatement` measured a package that doesn't exist. Now `.PHONY` is correct, the phantom prerequisite is gone, and coverage points at the real `src/ofxstatement_otp` (verified: 95% total).

## 2. Tolerate a missing transaction datetime on booked rows
`split_records` skips rows with no booking date, but a *booked* row could still have a blank transaction datetime, which was passed straight to `datetime.strptime` and raised `TypeError` mid-parse, aborting the whole conversion. Such a row is now emitted with `date_user` unset, and `Transaction.transaction_date` is widened to `Optional[datetime]`.

## 3. Don't use the account filter as a fallback `account_id`
When an `account` filter matched no rows, `_get_account_id` returned the filter string itself, so the OFX claimed to belong to an account whose number was just the user's filter substring, with zero transactions. It now returns `None` and logs a warning.

## Testing
Per the repo's mandatory TDD workflow, fixes 2 and 3 each landed as a failing test first (fix 1 is a build-file change). Full suite: **17 passed**, `mypy` clean, `black --check` clean.

https://claude.ai/code/session_011RcPEWLJrbfV4pHq1uCtS6

---
_Generated by [Claude Code](https://claude.ai/code/session_011RcPEWLJrbfV4pHq1uCtS6)_