### PR TITLE
Hoist transaction-type map to a shared module-level constant

### DIFF
--- a/src/ofxstatement_otp/otp.py
+++ b/src/ofxstatement_otp/otp.py
@@ -10,6 +10,8 @@ from ofxstatement.plugin import Plugin
 from ofxstatement.parser import StatementParser
 from ofxstatement.statement import Statement, StatementLine
 
+from ofxstatement_otp.transaction_types import transaction_type
+
 logger = logging.getLogger("OTP")
 
 TRANSACTIONS_SHEET_NAME = "Tranzakciók"
@@ -225,31 +227,4 @@ class OtpXlsxParser(StatementParser):
         return None
 
     def _get_transaction_type(self, transaction: Transaction) -> str:
-        trans_map = {
-            "NAPKÖZBENI ÁTUTALÁS": "XFER",
-            "VÁSÁRLÁS KÁRTYÁVAL": "POS",
-            "ESETI MEGBÍZÁSOK KÖLTSÉGE": "SRVCHG",
-            "AZONNALI ÁTUTALÁS": "XFER",
-            "ÁRUVISSZAVÉT ELLENÉRTÉKE": "POS",
-            "ÉRTÉKPAPÍR ÁLLANDÓ VÉTELI MB": "XFER",
-            "ZÁRLATI DÍJ": "SRVCHG",
-            "LAKÁSTAKARÉK BETÉT TERHELÉSE": "XFER",
-            "HITELTÖRLESZTÉS EGYÉB": "XFER",
-            "HITELTÖRLESZTÉS BESZEDÉSE": "SRVCHG",
-            "Minimum fizetendő összeg besz.díja": "SRVCHG",
-            "ÁTUTALÁS (OTP-N BELÜL)": "XFER",
-            "AZONNALI ÁTUTALÁS BANKON BELÜL": "XFER",
-            "KONVERZIÓ ÜGYF.HUFSZLÁRÓL DEVSZLÁRA": "XFER",
-            "TERHELÉS": "PAYMENT",
-            "HITELTÖRLESZTÉS BEFIZETÉS / ÁTUTALÁ": "PAYMENT",
-            "PÉNZÁTVEZ. ÉRTÉKPAPÍR SZLA-RÓL": "XFER",
-            "IDŐSZAKOS KÖLTSÉGEK": "SRVCHG",
-            "KAMATJÓVÁÍRÁS": "XFER",
-            "PRIVÁT BANKI CSOMAGDÍJ": "SRVCHG",
-            "20TBE0561242 BÉT vétel  HB": "PAYMENT",
-            "EGYÉB BIZTOSÍTÁSI DÍJ": "PAYMENT",
-        }
-        try:
-            return trans_map[transaction.description.strip()]
-        except KeyError:
-            return "PAYMENT"
+        return transaction_type(transaction.description)

--- a/src/ofxstatement_otp/otp_legacy.py
+++ b/src/ofxstatement_otp/otp_legacy.py
@@ -16,6 +16,8 @@ from ofxstatement.plugin import Plugin
 from ofxstatement.parser import StatementParser
 from ofxstatement.statement import Statement, StatementLine, generate_transaction_id
 
+from ofxstatement_otp.transaction_types import transaction_type
+
 logger = logging.getLogger("OTP")
 
 TRANSACTIONS_SHEET_NAME = "Tranzakciók"
@@ -129,34 +131,7 @@ class OtpLegacyXlsxParser(StatementParser):
             yield Transaction(*values)
 
     def _get_transaction_type(self, transaction: Transaction) -> str:
-        trans_map = {
-            "NAPKÖZBENI ÁTUTALÁS": "XFER",
-            "VÁSÁRLÁS KÁRTYÁVAL": "POS",
-            "ESETI MEGBÍZÁSOK KÖLTSÉGE": "SRVCHG",
-            "AZONNALI ÁTUTALÁS": "XFER",
-            "ÁRUVISSZAVÉT ELLENÉRTÉKE": "POS",
-            "ÉRTÉKPAPÍR ÁLLANDÓ VÉTELI MB": "XFER",
-            "ZÁRLATI DÍJ": "SRVCHG",
-            "LAKÁSTAKARÉK BETÉT TERHELÉSE": "XFER",
-            "HITELTÖRLESZTÉS EGYÉB": "XFER",
-            "HITELTÖRLESZTÉS BESZEDÉSE": "SRVCHG",
-            "Minimum fizetendő összeg besz.díja": "SRVCHG",
-            "ÁTUTALÁS (OTP-N BELÜL)": "XFER",
-            "AZONNALI ÁTUTALÁS BANKON BELÜL": "XFER",
-            "KONVERZIÓ ÜGYF.HUFSZLÁRÓL DEVSZLÁRA": "XFER",
-            "TERHELÉS": "PAYMENT",
-            "HITELTÖRLESZTÉS BEFIZETÉS / ÁTUTALÁ": "PAYMENT",
-            "PÉNZÁTVEZ. ÉRTÉKPAPÍR SZLA-RÓL": "XFER",
-            "IDŐSZAKOS KÖLTSÉGEK": "SRVCHG",
-            "KAMATJÓVÁÍRÁS": "XFER",
-            "PRIVÁT BANKI CSOMAGDÍJ": "SRVCHG",
-            "20TBE0561242 BÉT vétel  HB": "PAYMENT",
-            "EGYÉB BIZTOSÍTÁSI DÍJ": "PAYMENT",
-        }
-        try:
-            return trans_map[transaction.description.strip()]
-        except KeyError:
-            return "PAYMENT"
+        return transaction_type(transaction.description)
 
     def _get_start_balance(self):
         return None

--- a/src/ofxstatement_otp/transaction_types.py
+++ b/src/ofxstatement_otp/transaction_types.py
@@ -1,0 +1,43 @@
+"""Shared mapping from OTP transaction descriptions to OFX trntype codes.
+
+Both the current (``otp``) and legacy (``otp_legacy``) plugins read the same
+set of Hungarian transaction descriptions, so the table lives here as a single
+module-level constant -- built once at import time rather than rebuilt on every
+lookup inside each plugin.
+"""
+
+DEFAULT_TYPE = "PAYMENT"
+
+TRANS_MAP = {
+    "NAPKÖZBENI ÁTUTALÁS": "XFER",
+    "VÁSÁRLÁS KÁRTYÁVAL": "POS",
+    "ESETI MEGBÍZÁSOK KÖLTSÉGE": "SRVCHG",
+    "AZONNALI ÁTUTALÁS": "XFER",
+    "ÁRUVISSZAVÉT ELLENÉRTÉKE": "POS",
+    "ÉRTÉKPAPÍR ÁLLANDÓ VÉTELI MB": "XFER",
+    "ZÁRLATI DÍJ": "SRVCHG",
+    "LAKÁSTAKARÉK BETÉT TERHELÉSE": "XFER",
+    "HITELTÖRLESZTÉS EGYÉB": "XFER",
+    "HITELTÖRLESZTÉS BESZEDÉSE": "SRVCHG",
+    "Minimum fizetendő összeg besz.díja": "SRVCHG",
+    "ÁTUTALÁS (OTP-N BELÜL)": "XFER",
+    "AZONNALI ÁTUTALÁS BANKON BELÜL": "XFER",
+    "KONVERZIÓ ÜGYF.HUFSZLÁRÓL DEVSZLÁRA": "XFER",
+    "TERHELÉS": "PAYMENT",
+    "HITELTÖRLESZTÉS BEFIZETÉS / ÁTUTALÁ": "PAYMENT",
+    "PÉNZÁTVEZ. ÉRTÉKPAPÍR SZLA-RÓL": "XFER",
+    "IDŐSZAKOS KÖLTSÉGEK": "SRVCHG",
+    "KAMATJÓVÁÍRÁS": "XFER",
+    "PRIVÁT BANKI CSOMAGDÍJ": "SRVCHG",
+    "20TBE0561242 BÉT vétel  HB": "PAYMENT",
+    "EGYÉB BIZTOSÍTÁSI DÍJ": "PAYMENT",
+}
+
+
+def transaction_type(description: str) -> str:
+    """Map an OTP transaction description to an OFX trntype.
+
+    The description is stripped before lookup; unknown descriptions fall back
+    to ``PAYMENT``.
+    """
+    return TRANS_MAP.get(description.strip(), DEFAULT_TYPE)

--- a/tests/test_transaction_types.py
+++ b/tests/test_transaction_types.py
@@ -1,0 +1,31 @@
+"""Tests for the shared transaction-type mapping used by both plugins.
+
+The mapping from OTP transaction descriptions to OFX trntype codes is identical
+for the current and legacy exports, so it lives in one module-level table rather
+than being rebuilt on every lookup inside each plugin.
+"""
+
+from ofxstatement_otp.transaction_types import TRANS_MAP, transaction_type
+
+
+def test_known_descriptions_map_to_their_codes():
+    assert transaction_type("VÁSÁRLÁS KÁRTYÁVAL") == "POS"
+    assert transaction_type("NAPKÖZBENI ÁTUTALÁS") == "XFER"
+    assert transaction_type("ZÁRLATI DÍJ") == "SRVCHG"
+
+
+def test_unknown_description_defaults_to_payment():
+    assert transaction_type("NINCS ILYEN TÍPUS") == "PAYMENT"
+
+
+def test_description_is_stripped_before_lookup():
+    assert transaction_type("  VÁSÁRLÁS KÁRTYÁVAL  ") == "POS"
+
+
+def test_both_plugins_delegate_to_the_shared_helper():
+    # Guard against re-introducing a per-plugin copy of the table.
+    from ofxstatement_otp import otp, otp_legacy
+
+    assert otp.transaction_type is transaction_type
+    assert otp_legacy.transaction_type is transaction_type
+    assert isinstance(TRANS_MAP, dict)


### PR DESCRIPTION
Folds together review items 2.1 (duplicated table) and 2.2 (rebuilt per call) for the transaction-type mapping.

## Problem
Both plugins defined an identical ~22-entry `description -> trntype` dictionary *inside* `_get_transaction_type`, so:
- the dict was rebuilt on every single transaction lookup, and
- the table was copied verbatim across `otp.py` and `otp_legacy.py`, free to drift apart.

## Change
- New module `src/ofxstatement_otp/transaction_types.py` holds the table as a single module-level `TRANS_MAP` constant (built once at import) plus a `transaction_type()` helper (strips the description, falls back to `PAYMENT`).
- Both `otp.py` and `otp_legacy.py` now delegate to `transaction_type()`; the inline dicts are gone.

Behaviour is unchanged — the helper preserves the previous strip + `PAYMENT`-default semantics.

## Testing
Per the repo's TDD workflow, a failing unit test (`tests/test_transaction_types.py`) was written first, then the module created to satisfy it. The new tests cover known mappings, the `PAYMENT` fallback, description stripping, and that both plugins delegate to the shared helper (guarding against a per-plugin copy returning). Existing parser trntype tests still pass.

Full suite: **21 passed**, `mypy` clean, `black --check` clean.

https://claude.ai/code/session_011RcPEWLJrbfV4pHq1uCtS6

---
_Generated by [Claude Code](https://claude.ai/code/session_011RcPEWLJrbfV4pHq1uCtS6)_