### PR TITLE
Name parsing locals and build Transaction by keyword

### DIFF
--- a/src/ofxstatement_otp/otp.py
+++ b/src/ofxstatement_otp/otp.py
@@ -150,28 +150,53 @@ class OtpXlsxParser(StatementParser):
                 logger.debug("Skipping hidden row: %s", row)
                 continue
 
-            values = [
-                self.sheet.cell(row=row, column=col).value for col in range(1, 12)
-            ]
+            cells = [self.sheet.cell(row=row, column=col).value for col in range(1, 12)]
+            (
+                account_no,
+                partner_account,
+                partner_name,
+                description,
+                memo,
+                category,
+                bank_txn_id,
+                transaction_date,
+                booking_date,
+                amount,
+                currency,
+            ) = cells
 
             # stop at the first row without an account number
-            if not values[0]:
+            if not account_no:
                 break
 
             # skip rows without a booking date (e.g. pending items)
-            if not values[8]:
+            if not booking_date:
                 logger.debug("Skipping incomplete row: %s", row)
                 continue
 
             # only emit the configured account, if filtering is enabled
-            if not self._included(values[0]):
+            if not self._included(account_no):
                 continue
 
-            # The row is booked (booking date present, checked above); the
-            # transaction datetime may still be blank, so guard it.
-            values[7] = _to_datetime(values[7], DATETIME_FORMAT) if values[7] else None
-            values[8] = _to_datetime(values[8], DATE_FORMAT)
-            yield Transaction(*values)
+            yield Transaction(
+                account_no=account_no,
+                partner_account=partner_account,
+                partner_name=partner_name,
+                description=description,
+                memo=memo,
+                category=category,
+                bank_txn_id=bank_txn_id,
+                # The row is booked (booking date present, checked above); the
+                # transaction datetime may still be blank, so guard it.
+                transaction_date=(
+                    _to_datetime(transaction_date, DATETIME_FORMAT)
+                    if transaction_date
+                    else None
+                ),
+                booking_date=_to_datetime(booking_date, DATE_FORMAT),
+                amount=amount,
+                currency=currency,
+            )
 
     def _get_account_id(self) -> Optional[str]:
         # When filtering, report the filtered account; otherwise fall back to

--- a/src/ofxstatement_otp/otp_legacy.py
+++ b/src/ofxstatement_otp/otp_legacy.py
@@ -104,8 +104,22 @@ class OtpLegacyXlsxParser(StatementParser):
                 )
             ]
 
-            values = [*map(lambda x: x.value, data[0])]
-            logger.debug(values)
+            cells = [*map(lambda x: x.value, data[0])]
+            logger.debug(cells)
+            (
+                transaction_date,
+                booking_date,
+                description,
+                in_or_out,
+                partner_name,
+                partner_account,
+                otp_generated_category,
+                memo,
+                account_name,
+                account_no,
+                amount,
+                currency,
+            ) = cells
 
             # skip hidden rows -- some filters are applied as such
             if wb.active.row_dimensions[starting_row + offset].hidden:
@@ -114,19 +128,32 @@ class OtpLegacyXlsxParser(StatementParser):
                 continue
 
             # stop when we reach the end of the file
-            if not values[0]:
+            if not transaction_date:
                 break
 
             # skip lines without parseable dates
-            if not values[1]:
+            if not booking_date:
                 logger.debug("Skipping incomplete row: " + str(starting_row + offset))
                 offset += 1
                 continue
 
-            values[0] = datetime.strptime(values[0], "%Y-%m-%d %H:%M:%S")
-            values[1] = datetime.strptime(values[1], "%Y-%m-%d")
             offset += 1
-            yield Transaction(*values)
+            yield Transaction(
+                transaction_date=datetime.strptime(
+                    transaction_date, "%Y-%m-%d %H:%M:%S"
+                ),
+                booking_date=datetime.strptime(booking_date, "%Y-%m-%d"),
+                description=description,
+                in_or_out=in_or_out,
+                partner_name=partner_name,
+                partner_account=partner_account,
+                otp_generated_category=otp_generated_category,
+                memo=memo,
+                account_name=account_name,
+                account_no=account_no,
+                amount=amount,
+                currency=currency,
+            )
 
     def _get_transaction_type(self, transaction: Transaction) -> str:
         trans_map = {


### PR DESCRIPTION
Improves readability of the two `_get_transactions` methods without extracting column positions into shared constants (which wouldn't reduce the real cost of a format change — as the legacy→current rewrite showed, those changes alter field *semantics*, not just column offsets).

## Problem
Both parsers read a row into an anonymous `values` list and referred to fields by raw index (`values[0]`, `values[7]`, `values[8]`), then built `Transaction(*values)`. The position→field mapping lived only in comments and the dataclass field order, and the *same* index meant different fields across the two differently-ordered formats (e.g. `values[0]` is the account number in `otp.py` but the transaction date in `otp_legacy.py`).

## Change
- Unpack each row into named locals in a single statement, so every field is named once, where the parsing happens.
- Construct `Transaction` with keyword arguments, so the call no longer silently depends on positional alignment with the dataclass.
- The position→field mapping stays local to each parser (that's these functions' job); it's just self-documenting now.

Applied to both `otp.py` and `otp_legacy.py`. The legacy loop mechanics (`offset`/`while`) and per-call workbook load are intentionally left untouched — those are separate review items.

## Testing
Behaviour-preserving refactor, guarded by the existing suites (payees, amounts, dates, trntypes, skip paths for hidden/incomplete rows). **17 passed**, `mypy` clean, `black --check` clean.

https://claude.ai/code/session_011RcPEWLJrbfV4pHq1uCtS6

---
_Generated by [Claude Code](https://claude.ai/code/session_011RcPEWLJrbfV4pHq1uCtS6)_